### PR TITLE
Cake 5 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,12 @@
     "type": "cakephp-plugin",
     "license": "MIT",
     "require": {
-        "php": "^7.2|^8.0",
-        "phpoffice/phpspreadsheet": "^1.1",
-        "cakephp/filesystem": "~4.0",
-        "cakephp/orm": "~4.0"
+        "php": ">=8.1",
+        "phpoffice/phpspreadsheet": "^2.0",
+        "cakephp/orm": "~5.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "~4.0",
+        "cakephp/cakephp": "~5.0",
         "cakephp/cakephp-codesniffer": "*",
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.9"

--- a/src/Excel/Manager.php
+++ b/src/Excel/Manager.php
@@ -26,7 +26,6 @@
 namespace Robotusers\Excel\Excel;
 
 use Cake\Datasource\EntityInterface;
-use Cake\Filesystem\File;
 use Cake\ORM\Table;
 use DateTimeInterface;
 use InvalidArgumentException;
@@ -43,6 +42,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer\Csv as CsvWriter;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
 use UnexpectedValueException;
+use SplFileInfo;
 
 /**
  * Description of Manager
@@ -292,7 +292,7 @@ class Manager
      * @return Spreadsheet
      * @deprecated 0.5.0 Use `getSpreadsheet()` instead.
      */
-    public function getExcel(File $file, array $options = [])
+    public function getExcel(SplFileInfo $file, array $options = [])
     {
         return $this->getSpreadsheet($file, $options);
     }
@@ -302,11 +302,11 @@ class Manager
      * @param array $options
      * @return Spreadsheet
      */
-    public function getSpreadsheet(File $file, array $options = [])
+    public function getSpreadsheet(SplFileInfo $file, array $options = [])
     {
         $reader = $this->getReader($file, $options);
 
-        return $reader->load($file->pwd());
+        return $reader->load($file->getRealPath());
     }
 
     /**
@@ -316,14 +316,14 @@ class Manager
      * @return IReader
      * @throws InvalidArgumentException
      */
-    public function getReader(File $file, array $options = [])
+    public function getReader(SplFileInfo $file, array $options = [])
     {
-        if (!$file->exists()) {
-            $message = sprintf('File %s does not exist.', $file->name());
+        if (!$file->getSize()) {
+            $message = sprintf('File %s does not exist.', $file->getBasename());
             throw new InvalidArgumentException($message);
         }
 
-        $reader = IOFactory::createReaderForFile($file->pwd());
+        $reader = IOFactory::createReaderForFile($file->getRealPath());
 
         if ($reader instanceof CsvReader) {
             if (isset($options['delimiter'])) {
@@ -354,14 +354,14 @@ class Manager
     public function getWriter(Spreadsheet $excel, File $file, array $options = [])
     {
         if (!$file->exists()) {
-            $message = sprintf('File %s does not exist.', $file->name());
+            $message = sprintf('File %s does not exist.', $file->getBasename());
             throw new InvalidArgumentException($message);
         }
 
         if (isset($options['writerType'])) {
             $type = $options['writerType'];
         } else {
-            $type = IOFactory::identify($file->pwd());
+            $type = IOFactory::identify($file->getRealPath());
         }
         $writer = IOFactory::createWriter($excel, $type);
 
@@ -393,7 +393,7 @@ class Manager
     public function save(Spreadsheet $excel, File $file, array $options = [])
     {
         $writer = $this->getWriter($excel, $file, $options);
-        $writer->save($file->pwd());
+        $writer->save($file->getRealPath());
 
         return $file;
     }

--- a/src/Excel/Manager.php
+++ b/src/Excel/Manager.php
@@ -353,7 +353,7 @@ class Manager
      */
     public function getWriter(Spreadsheet $excel, File $file, array $options = [])
     {
-        if (!$file->exists()) {
+        if (!$file->getSize()) {
             $message = sprintf('File %s does not exist.', $file->getBasename());
             throw new InvalidArgumentException($message);
         }

--- a/src/Excel/Manager.php
+++ b/src/Excel/Manager.php
@@ -351,7 +351,7 @@ class Manager
      * @return IWriter
      * @throws InvalidArgumentException
      */
-    public function getWriter(Spreadsheet $excel, File $file, array $options = [])
+    public function getWriter(Spreadsheet $excel, SplFileInfo $file, array $options = [])
     {
         if (!$file->getSize()) {
             $message = sprintf('File %s does not exist.', $file->getBasename());

--- a/src/Model/Behavior/ExcelBehavior.php
+++ b/src/Model/Behavior/ExcelBehavior.php
@@ -26,7 +26,6 @@
 namespace Robotusers\Excel\Model\Behavior;
 
 use Cake\Datasource\EntityInterface;
-use Cake\Filesystem\File;
 use Cake\ORM\Behavior;
 use Cake\ORM\Table;
 use InvalidArgumentException;
@@ -35,6 +34,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Robotusers\Excel\Excel\Manager;
 use Robotusers\Excel\Traits\DiscoverWorksheetTrait;
 use RuntimeException;
+use SplFileInfo;
 
 /**
  * Description of ExcelBehavior
@@ -68,7 +68,7 @@ class ExcelBehavior extends Behavior
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'startRow' => 1,
         'endRow' => null,
         'startColumn' => 'A',
@@ -164,7 +164,7 @@ class ExcelBehavior extends Behavior
         ]);
         $writer = $manager->getWriter($worksheet->getParent(), $file, $options);
 
-        $writer->save($file->pwd());
+        $writer->save($file->getRealPath());
 
         return $file;
     }
@@ -263,7 +263,7 @@ class ExcelBehavior extends Behavior
      * @param File $file
      * @return Table
      */
-    public function setFile(File $file)
+    public function setFile(SplFileInfo $file)
     {
         $this->file = $file;
 

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -28,14 +28,15 @@ namespace Robotusers\Excel;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
-use Cake\Filesystem\File;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
+use Cake\Utility\Security;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Robotusers\Excel\Database\Factory;
 use Robotusers\Excel\Excel\Manager;
 use Robotusers\Excel\Model\Sheet;
 use Robotusers\Excel\Traits\DiscoverWorksheetTrait;
+use SplFileInfo;
 
 /**
  * Description of SheetLoader
@@ -92,7 +93,7 @@ class Registry
 
     /**
      *
-     * @param string|File $file
+     * @param string|SplFileInfo $file
      * @param string $sheet
      * @param array $options
      * @param array $locatorOptions
@@ -100,8 +101,8 @@ class Registry
      */
     public function get($file, $sheet = null, array $options = [], array $locatorOptions = [])
     {
-        if (!$file instanceof File) {
-            $file = new File($file);
+        if (!$file instanceof SplFileInfo) {
+            $file = new SplFileInfo($file);
         }
         if (is_array($sheet)) {
             $options = $sheet;
@@ -109,10 +110,10 @@ class Registry
         }
 
         $reader = $this->manager->getReader($file, $options);
-        $excel = $reader->load($file->pwd());
+        $excel = $reader->load($file->getRealPath());
         $worksheet = $this->discoverWorksheet($excel, $sheet);
 
-        $hash = $file->md5();
+        $hash = Security::hash($file->getRealPath(),'md5');
         $sheetId = $excel->getIndex($worksheet);
 
         if (!isset($this->sheets[$hash][$sheetId])) {
@@ -134,7 +135,7 @@ class Registry
      * @param array $options
      * @return Sheet
      */
-    protected function loadSheet(File $file, Worksheet $worksheet, array $options)
+    protected function loadSheet(SplFileInfo $file, Worksheet $worksheet, array $options)
     {
         $schema = $this->factory->createSchema($worksheet, $options['excel']);
         $connection = $this->getConnection();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,9 +24,9 @@
  */
 namespace Robotusers\Excel\Test;
 
-use Cake\Filesystem\File;
 use Cake\TestSuite\TestCase as CakeTestCase;
 use InvalidArgumentException;
+use SplFileInfo;
 
 /**
  * Description of TestCase
@@ -66,8 +66,8 @@ class TestCase extends CakeTestCase
     {
         $file = $this->getFile($filename);
 
-        $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReaderForFile($file->pwd());
-        $excel = $reader->load($file->pwd());
+        $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReaderForFile($file->getRealPath());
+        $excel = $reader->load($file->getRealPath());
 
         return $excel->getSheet($sheetIndex);
     }

--- a/tests/TestCase/Excel/ManagerTest.php
+++ b/tests/TestCase/Excel/ManagerTest.php
@@ -26,7 +26,6 @@ namespace Robotusers\Excel\Test\TestCase\Excel;
 
 use Cake\Chronos\Chronos;
 use Cake\Chronos\Date;
-use Cake\Filesystem\File;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use InvalidArgumentException;
@@ -40,6 +39,7 @@ use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use Robotusers\Excel\Excel\Manager;
 use Robotusers\Excel\Test\TestCase;
 use UnexpectedValueException;
+use SplFileInfo;
 
 /**
  * Description of ManagerTest
@@ -68,10 +68,10 @@ class ManagerTest extends TestCase
         $this->expectExceptionMessage('File foo does not exist.');
 
         $manager = new Manager();
-        $file = $this->createMock(File::class);
-        $file->method('exists')
+        $file = $this->createMock(SplFileInfo::class);
+        $file->method('getSize')
             ->willReturn(false);
-        $file->method('name')
+        $file->method('getBasename')
             ->willReturn('foo');
 
         $manager->getReader($file);
@@ -83,11 +83,11 @@ class ManagerTest extends TestCase
         $this->expectExceptionMessage('File foo does not exist.');
         
         $manager = new Manager();
-        $file = $this->createMock(File::class);
+        $file = $this->createMock(SplFileInfo::class);
         $excel = $this->createMock(Spreadsheet::class);
-        $file->method('exists')
+        $file->method('getSize')
             ->willReturn(false);
-        $file->method('name')
+        $file->method('getBasename')
             ->willReturn('foo');
 
         $manager->getWriter($excel, $file);
@@ -763,7 +763,7 @@ class ManagerTest extends TestCase
 
         $writer->expects($this->once())
             ->method('save')
-            ->with($file->pwd());
+            ->with($file->getRealPath());
 
         $manager = new Manager();
 

--- a/tests/TestCase/Model/Behavior/ExcelBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ExcelBehaviorTest.php
@@ -27,7 +27,6 @@ namespace Robotusers\Excel\Test\TestCase\Model\Behavior;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventList;
 use Cake\Event\EventManager;
-use Cake\Filesystem\File;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use InvalidArgumentException;
@@ -36,6 +35,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Robotusers\Excel\Excel\Manager;
 use Robotusers\Excel\Test\TestCase;
 use RuntimeException;
+use SplFileInfo;
 use stdClass;
 
 /**
@@ -150,7 +150,7 @@ class ExcelBehaviorTest extends TestCase
         $excel = $this->createMock(Spreadsheet::class);
         $manager = $this->createMock(Manager::class);
         $worksheet = $this->createMock(Worksheet::class);
-        $file = $this->createMock(File::class);
+        $file = $this->createMock(SplFileInfo::class);
 
         $table = $this->createTable([
             'manager' => $manager
@@ -181,7 +181,7 @@ class ExcelBehaviorTest extends TestCase
         $excel = $this->createMock(Spreadsheet::class);
         $manager = $this->createMock(Manager::class);
         $worksheet = $this->createMock(Worksheet::class);
-        $file = $this->createMock(File::class);
+        $file = $this->createMock(SplFileInfo::class);
 
         $table = $this->createTable([
             'manager' => $manager
@@ -217,7 +217,7 @@ class ExcelBehaviorTest extends TestCase
         $excel = $this->createMock(Spreadsheet::class);
         $manager = $this->createMock(Manager::class);
         $worksheet = $this->createMock(Worksheet::class);
-        $file = $this->createMock(File::class);
+        $file = $this->createMock(SplFileInfo::class);
 
         $table = $this->createTable([
             'manager' => $manager
@@ -253,7 +253,7 @@ class ExcelBehaviorTest extends TestCase
         $excel = $this->createMock(Spreadsheet::class);
         $manager = $this->createMock(Manager::class);
         $worksheet = $this->createMock(Worksheet::class);
-        $file = $this->createMock(File::class);
+        $file = $this->createMock(SplFileInfo::class);
 
         $table = $this->createTable([
             'manager' => $manager


### PR DESCRIPTION
- use SplFileInfo instead of removed Cake\Filesystem\File
- crank phpoffice/phpspreadsheet to ^2.0 because of PHP 8.1 requirement for Cake 5